### PR TITLE
設定画面での名前が attribute key になってしまっていたのを修正した

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -2,9 +2,9 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
     class SwordWorld25SpeedProvider extends SpeedProvider {
         get colors() {
             return [
-                {id: "limited", default: 0x0080FF, name: "speeds.limited"},
-                {id: "normal", default: 0x80FF00, name: "speeds.normal"},
-                {id: "max", default: 0xFF8000, name: "speeds.max"}
+                {id: "limited", default: 0x0080FF, name: "制限移動"},
+                {id: "normal", default: 0x80FF00, name: "通常移動"},
+                {id: "max", default: 0xFF8000, name: "全力移動"}
             ];
         }
 


### PR DESCRIPTION
設定画面のネームタグに属性キーを設定しまっていた。
![img-before](https://github.com/lunachil32/fvtt-drag-ruler-sw25/assets/17611190/3d679225-dd3d-478b-8f0b-f7ee1d7a9413)

それぞれの名前を表示する形へ変更した。
![img-after](https://github.com/lunachil32/fvtt-drag-ruler-sw25/assets/17611190/7d4feaf3-ae38-48ed-8204-381d16d47734)


厳密やるのであれば i18n のためのキーを渡してやるべき？なのかもしれない。
追々で対応したい。